### PR TITLE
Update README.md to add support for downstream distros

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ sudo chmod a+r /etc/apt/keyrings/xlibre-deb.asc
 cat <<EOF | sudo tee /etc/apt/sources.list.d/xlibre-deb.sources
 Types: deb deb-src
 URIs: https://xlibre-deb.github.io/debian/
-Suites: $(. /etc/os-release && echo "$VERSION_CODENAME")
+Suites: $(. /etc/os-release && echo "$DEBIAN_CODENAME")
 Components: main
 Architectures: $(dpkg --print-architecture)
 Signed-By: /etc/apt/keyrings/xlibre-deb.asc
@@ -23,7 +23,7 @@ sudo apt-get install xlibre
 
 ## For Debian 12 (bookworm) users
 
-You may need to install `libdrm*` packages from Debian `bookworm-backports` repository.
+You may need to install `libdrm*` packages from Debian `bookworm-backports` repository. Some derivatives such as LMDE6 will have backports enabled by default so you can skip that step
 
 ```sh
 cat <<EOF | sudo tee /etc/apt/sources.list.d/debian-backports.sources
@@ -34,7 +34,10 @@ Components: main
 Enabled: yes
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOF
+```
 
+
+```sh
 sudo apt-get update
 sudo apt-get install -y -t bookworm-backports 'libdrm*'
 ```


### PR DESCRIPTION
same as for ubuntu that downstram distros will need to reference the DEBIAN_CODENAME like to get the correct repository